### PR TITLE
Updates pngjs to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Crop and save PNGs",
   "main": "index.js",
   "dependencies": {
-    "pngjs": "^0.4.0",
+    "pngjs": "^2.3.1",
     "promise": "^6.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
The old repo for 0.4.0 is no longer maintained and the current version on npm
now points to this fork - https://github.com/lukeapage/pngjs
